### PR TITLE
This ensures replacing the correct placeholder.

### DIFF
--- a/src/net/mmberg/nadia/processor/dialogmodel/Action.java
+++ b/src/net/mmberg/nadia/processor/dialogmodel/Action.java
@@ -93,7 +93,7 @@ public abstract class Action extends ActionModel{
 			while (matcher.find()) {
 				ito_name=matcher.group(1);
 				if(frame.get(ito_name)!=null){
-					answer=answer.replaceFirst("%(\\w+)",frame.get(ito_name).toString());
+					answer=answer.replaceFirst("%"+ito_name,frame.get(ito_name).toString());
 				}
 			}
 		}


### PR DESCRIPTION
In the old version, if a non-required ITO exists in the utterance template, a slot that occurs after the non-required ITO would fill the non-required ITO.

I don't know why github can't diff the files, but the change is at processor/dialogmodel/Action.java.
